### PR TITLE
Set max peers to 50

### DIFF
--- a/geth/entrypoint.sh
+++ b/geth/entrypoint.sh
@@ -40,7 +40,7 @@ exec geth --datadir /lukso \
   --miner.gasprice 1000000000 \
   --miner.gaslimit 42000000 \
   --bootnodes enode://c2bb19ce658cfdf1fecb45da599ee6c7bf36e5292efb3fb61303a0b2cd07f96c20ac9b376a464d687ac456675a2e4a44aec39a0509bcb4b6d8221eedec25aca2@34.147.73.193:30303", "enode://276f14e4049840a0f5aa5e568b772ab6639251149a52ba244647277175b83f47b135f3b3d8d846cf81a8e681684e37e9fc10ec205a9841d3ae219aa08aa9717b@34.32.192.211:30303 \
-  --maxpeers 100 \
+  --maxpeers 50 \
   --port ${P2P_PORT} \
   --http \
   --http.api eth,engine,net,web3,txpool \


### PR DESCRIPTION
Set max peers to default value (50), in order to reduce network and computation resources consumption